### PR TITLE
fix AttributeError: 'KitNET' object has no attribute 'ensembleLayer' when passing feature_map paramter to KitNET

### DIFF
--- a/KitNET/KitNET.py
+++ b/KitNET/KitNET.py
@@ -33,6 +33,8 @@ class KitNET:
         self.n = n
 
         # Variables
+        self.ensembleLayer = []
+        self.outputLayer = None
         self.n_trained = 0 # the number of training instances so far
         self.n_executed = 0 # the number of executed instances so far
         self.v = feature_map
@@ -42,8 +44,6 @@ class KitNET:
             self.__createAD__()
             print("Feature-Mapper: execute-mode, Anomaly-Detector: train-mode")
         self.FM = CC.corClust(self.n) #incremental feature cluatering for the feature mapping process
-        self.ensembleLayer = []
-        self.outputLayer = None
 
     #If FM_grace_period+AM_grace_period has passed, then this function executes KitNET on x. Otherwise, this function learns from x.
     #x: a numpy array of length n


### PR DESCRIPTION
Hi, I`m currently researching on NIDS. First, thank you for your contribution to this area, Kitsune is well known for its performance and low resource consumption, and many researches cannot be done without it. 

When I`m trying to use KitNET of Kitsune directly, I ran into a problem of "AttributeError: 'KitNET' object has no attribute 'ensembleLayer'", then I found than when feature_map is passed, this problem is about to happen. So I made this PR to fix it.

This PR makes ensembleLayer and outputLayer initializes before running \_\_createAD__, so the attribute is set before appending something.

(I`m not a native English speaker, apologize if I said anything offensive and grammar errors)